### PR TITLE
feature: hide in locked_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ plugins {
         // E.g. if you have set default_mode to "locked", then
         // you can hide hints in the locked mode by setting this to true
         hide_in_base_mode false // default
+        // Hide hints in locked mode
+        // Usefull if the default Ctrl+g shortcut
+        // enables and disables this mode
+        hide_in_locked_mode false // default
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ struct State {
     max_length: usize,
     overflow_str: String,
     hide_in_base_mode: bool,
+    hide_in_locked_mode: bool,
 }
 
 register_plugin!(State);
@@ -119,6 +120,10 @@ impl ZellijPlugin for State {
             .get("hide_in_base_mode")
             .map(|s| s.to_lowercase().parse::<bool>().unwrap_or(false))
             .unwrap_or(false);
+        self.hide_in_locked_mode = configuration
+            .get("hide_in_locked_mode")
+            .map(|s| s.to_lowercase().parse::<bool>().unwrap_or(false))
+            .unwrap_or(false);
 
         request_permission(&[
             PermissionType::ReadApplicationState,
@@ -143,7 +148,7 @@ impl ZellijPlugin for State {
 
     fn render(&mut self, _rows: usize, _cols: usize) {
         let mode_info = &self.mode_info;
-        let output = if !(self.hide_in_base_mode && Some(mode_info.mode) == mode_info.base_mode) {
+        let output = if !(self.hide_in_locked_mode && mode_info.mode == InputMode::Locked) && !(self.hide_in_base_mode && Some(mode_info.mode) == mode_info.base_mode) {
             let keymap = get_keymap_for_mode(mode_info);
             let parts = render_hints_for_mode(mode_info.mode, &keymap, &mode_info.style.colors);
 


### PR DESCRIPTION
Hello,

Thanks for this great plugin!

I have no need to display `Ctrl + g` at all times.
And I presume others feel the same.