### PR TITLE
Combine #30 + #32 + bump zellij-tile to 0.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,180 +57,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
+ "event-listener",
  "futures-core",
 ]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.1",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.6.1",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling 3.11.0",
- "rustix 1.1.2",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite 2.6.1",
- "rustix 1.1.2",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.2",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.1",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -283,27 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,35 +130,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytemuck"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -384,12 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,9 +184,9 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap 1.9.3",
+ "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap 0.16.2",
 ]
@@ -545,6 +319,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm_winapi",
+ "mio 1.2.0",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,16 +351,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csscolorparser"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
-dependencies = [
- "lab",
- "phf",
 ]
 
 [[package]]
@@ -594,12 +383,6 @@ dependencies = [
  "vcpkg",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "deltae"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "derive_more"
@@ -686,6 +469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,12 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,50 +506,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "euclid"
-version = "0.22.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
 
 [[package]]
 name = "fastrand"
@@ -778,14 +527,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filedescriptor"
-version = "0.8.3"
+name = "filetime"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
+ "cfg-if",
  "libc",
- "thiserror 1.0.69",
- "winapi",
+ "libredox",
 ]
 
 [[package]]
@@ -793,18 +542,6 @@ name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
-
-[[package]]
-name = "finl_unicode"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -819,15 +556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -858,17 +586,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
+name = "futures-sink"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "generic-array"
@@ -910,43 +631,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -964,21 +664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +673,12 @@ dependencies = [
  "fnv",
  "itoa",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
@@ -1146,17 +837,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.11.4"
+name = "inotify"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "equivalent",
- "hashbrown 0.16.0",
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1170,15 +871,17 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "1.2.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
- "cfg-if",
+ "doctest-file",
+ "futures-core",
  "libc",
- "rustc_version",
- "to_method",
- "winapi",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1204,19 +907,19 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "castaway",
  "crossbeam-utils",
  "curl",
  "curl-sys",
  "encoding_rs",
- "event-listener 2.5.3",
- "futures-lite 1.13.0",
+ "event-listener",
+ "futures-lite",
  "http",
  "log",
  "mime",
  "once_cell",
- "polling 2.8.0",
+ "polling",
  "slab",
  "sluice",
  "tracing",
@@ -1262,19 +965,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
+name = "kqueue"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
- "log",
+ "kqueue-sys",
+ "libc",
 ]
 
 [[package]]
-name = "lab"
-version = "0.11.0"
+name = "kqueue-sys"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1283,10 +991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.177"
+name = "lev_distance"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "72d9d1bd215936bc8647ad92986bb56f3f216550b53c44ab785e3217ae33625e"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1306,6 +1020,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1352,9 +1067,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "log-mdc"
@@ -1383,41 +1095,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac_address"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
-dependencies = [
- "nix 0.29.0",
- "winapi",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memmem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1476,16 +1163,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
+name = "names"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "nix"
@@ -1497,20 +1211,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -1524,14 +1225,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
+name = "notify"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
+ "bitflags 2.9.4",
+ "filetime",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1583,15 +1290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,121 +1331,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.11.4",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project"
@@ -1776,23 +1363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,20 +1385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,13 +1394,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "proc-macro2",
- "syn 1.0.109",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1891,28 +1446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,15 +1456,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -1955,6 +1479,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1963,6 +1499,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -1996,70 +1541,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
-
-[[package]]
-name = "rmp"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -2100,6 +1585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,12 +1607,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2200,6 +1688,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.0",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,12 +1706,6 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2226,7 +1719,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "futures-core",
  "futures-io",
 ]
@@ -2275,27 +1768,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "suggest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2558d0d6327d908558f161bc862d365c0d33aa796bdc81c13c0f954868576659"
+dependencies = [
+ "clap",
+ "lev_distance",
 ]
 
 [[package]]
@@ -2366,7 +1863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
@@ -2388,69 +1884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminfo"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
-dependencies = [
- "fnv",
- "nom",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "termwiz"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
-dependencies = [
- "anyhow",
- "base64",
- "bitflags 2.9.4",
- "fancy-regex",
- "filedescriptor",
- "finl_unicode",
- "fixedbitset",
- "hex",
- "lazy_static",
- "libc",
- "log",
- "memmem",
- "nix 0.29.0",
- "num-derive",
- "num-traits",
- "ordered-float",
- "pest",
- "pest_derive",
- "phf",
- "sha2",
- "signal-hook",
- "siphasher",
- "terminfo",
- "termios",
- "thiserror 1.0.69",
- "ucd-trie",
- "unicode-segmentation",
- "vtparse",
- "wezterm-bidi",
- "wezterm-blob-leases",
- "wezterm-color-types",
- "wezterm-dynamic",
- "wezterm-input-types",
  "winapi",
 ]
 
@@ -2532,10 +1965,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "to_method"
-version = "1.1.0"
+name = "tokio"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio 1.2.0",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tracing"
@@ -2584,12 +2063,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -2651,18 +2124,11 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "atomic",
  "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -2698,19 +2164,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "vtparse"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
 name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2764,19 +2231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,98 +2263,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.81"
+name = "widestring"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wezterm-bidi"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
-dependencies = [
- "log",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-blob-leases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
-dependencies = [
- "getrandom 0.3.3",
- "mac_address",
- "sha2",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "wezterm-color-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
-dependencies = [
- "csscolorparser",
- "deltae",
- "lazy_static",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-dynamic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
-dependencies = [
- "log",
- "ordered-float",
- "strsim 0.11.1",
- "thiserror 1.0.69",
- "wezterm-dynamic-derive",
-]
-
-[[package]]
-name = "wezterm-dynamic-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "wezterm-input-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
-dependencies = [
- "bitflags 1.3.2",
- "euclid",
- "lazy_static",
- "serde",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -2999,6 +2365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3178,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.42.2"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4478011b065e4d5f2de8bbc9ba5d08cbc19e97817973b63f687727d7a2a048f8"
+checksum = "58db4c6d603137830de70f0fb7f0b43b3b87ce6596fb15e195f1034f53a06b59"
 dependencies = [
  "clap",
  "prost",
@@ -3193,21 +2568,20 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile-utils"
-version = "0.42.2"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6176ebf2612eafd2ac98818cadf91b7db8ae342458cde28b418a26498b12cba3"
+checksum = "f543a1f2e9b2d92e736b65966145e91a385de5cd2a1c6a6aa98d36dd2af81584"
 dependencies = [
  "ansi_term",
 ]
 
 [[package]]
 name = "zellij-utils"
-version = "0.42.2"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8411769c0ec1b0c7d561a3f64c96058fc54db54781642e911a5a555c2e7e52"
+checksum = "bdc716a4f9ba19fa7288d3a46eeecb1857fca02d250946fb0b55601b4e768e0a"
 dependencies = [
  "anyhow",
- "async-std",
  "backtrace",
  "bitflags 2.9.4",
  "clap",
@@ -3215,32 +2589,62 @@ dependencies = [
  "colored",
  "colorsys",
  "crossbeam",
+ "crossterm",
  "directories",
+ "dunce",
+ "humantime",
  "include_dir",
  "interprocess",
  "isahc",
  "kdl",
  "lazy_static",
+ "libc",
  "log",
  "log4rs",
  "miette",
- "nix 0.23.2",
+ "names",
+ "nix",
+ "notify",
  "percent-encoding",
  "prost",
- "prost-build",
- "rmp-serde",
  "serde",
  "serde_json",
+ "sha2",
  "shellexpand",
  "strip-ansi-escapes",
  "strum",
  "strum_macros",
+ "suggest",
  "tempfile",
- "termwiz",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
  "unicode-width",
  "url",
  "uuid",
+ "winapi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db4c6d603137830de70f0fb7f0b43b3b87ce6596fb15e195f1034f53a06b59"
+checksum = "1f5d8a3bb094f49b152493e9a2be94e2a988e36c7a0b83e125865e6b3c6f7131"
 dependencies = [
  "clap",
  "prost",
@@ -2568,18 +2568,18 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile-utils"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f543a1f2e9b2d92e736b65966145e91a385de5cd2a1c6a6aa98d36dd2af81584"
+checksum = "e83c66a72ea40614e84816673e22c4179a78ea48f8c150e6fb79b1ca68566e37"
 dependencies = [
  "ansi_term",
 ]
 
 [[package]]
 name = "zellij-utils"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc716a4f9ba19fa7288d3a46eeecb1857fca02d250946fb0b55601b4e768e0a"
+checksum = "dd3b8f962e5ffbfc3c378bbaf63893f469a652b57cbc1d95adc74f167aa023eb"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ rust-version = "1.84"
 
 [dependencies]
 ansi_term = "0.12"
-zellij-tile = "0.42.2"
-zellij-tile-utils = "0.42.2"
+zellij-tile = "0.44.1"
+zellij-tile-utils = "0.44.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ rust-version = "1.84"
 
 [dependencies]
 ansi_term = "0.12"
-zellij-tile = "0.44.1"
-zellij-tile-utils = "0.44.1"
+zellij-tile = "0.44.2"
+zellij-tile-utils = "0.44.2"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ plugins {
         // E.g. if you have set default_mode to "locked", then
         // you can hide hints in the locked mode by setting this to true
         hide_in_base_mode false // default
+
+        // How modifier keys are displayed. Options:
+        //   "long"   — "Ctrl + n", "Alt + h"  (default)
+        //   "short"  — "C-n", "A-h"
+        //   "symbol" — "^n", "M-h"
+        modifier_style "long" // default
+
+        // Template for each hint. Available variables: {key}, {action}
+        // Default matches current behavior: key block followed by action block
+        hint_format "{key} {action}" // default
+
+        // String inserted between hints (default: no separator)
+        separator "" // default
+
+        // Limit alternative keybindings shown per action (0 = unlimited)
+        max_keys "0" // default
+
+        // Rename action labels in the display (spaces → underscores in key names)
+        // alias_fullscreen "full"
+        // alias_split_right "S→"
+        // alias_select "sel"
+
+        // Rename special bare keys in the display
+        // key_alias_enter "⏎"
+        // key_alias_space "␣"
+
+        // Optional: override palette-derived colors with hex values (#RRGGBB)
+        // key_fg   "#ffffff"
+        // key_bg   "#6e5fb7"
+        // label_fg "#cccccc"
+        // label_bg "#4c435c"
     }
 }
 
@@ -66,14 +97,236 @@ layout {
 
 ## Configuration
 
-- `max_length`: Maximum number of characters to display (default: 0 = unlimited)
-- `overflow_str`: String to append when truncated (default: "...")
-- `pipe_name`: Name of the pipe for zjstatus integration (default: "zjstatus_hints")
-- `hide_in_base_mode`: Hide hints in base mode (a.k.a. default mode) (default: false)
+| Option | Default | Description |
+|---|---|---|
+| `max_length` | `0` | Maximum characters to display. `0` = unlimited. |
+| `overflow_str` | `"..."` | String appended when output is truncated. |
+| `pipe_name` | `"zjstatus_hints"` | Pipe name used for zjstatus integration. |
+| `hide_in_base_mode` | `false` | Hide hints when in the base (default) mode. |
+| `modifier_style` | `"long"` | How modifier keys are rendered. See below. |
+| `hint_format` | `"{key} {action}"` | Template for each hint. Variables: `{key}`, `{action}`. |
+| `separator` | `""` | String inserted between hints. |
+| `max_keys` | `0` | Max alternative keybindings shown per action. `0` = unlimited. |
+| `alias_{label}` | _(none)_ | Rename an action label in the display. See below. |
+| `key_alias_{key}` | _(none)_ | Rename a special bare key in the display. See below. |
+| `key_fg` | _(palette)_ | Global foreground color for key blocks. |
+| `key_bg` | _(palette)_ | Global background color for key blocks. |
+| `label_fg` | _(palette)_ | Global foreground color for action label blocks. |
+| `label_bg` | _(palette)_ | Global background color for action label blocks. |
+
+### `modifier_style`
+
+Controls how modifier keys such as Ctrl and Alt appear in key hints:
+
+| Value | Example output |
+|---|---|
+| `"long"` (default) | `Ctrl + n`, `Alt + h` |
+| `"short"` | `C-n`, `A-h` |
+| `"symbol"` | `^n`, `M-h` |
+
+### `hint_format`
+
+A template string applied to each individual hint. Two variables are available:
+
+- `{key}` — the formatted keybinding (respects `modifier_style`)
+- `{action}` — the action label (e.g. `new`, `close`, `fullscreen`)
+
+Examples:
+
+```kdl
+hint_format "{key} {action}"   // default: " Ctrl + n  new "
+hint_format "{key}:{action}"   // compact: "^n:new"
+hint_format "{action}[{key}]"  // action-first: "new[^n]"
+```
+
+### `separator`
+
+A string inserted between hint groups. Empty by default (hints are concatenated).
+
+```kdl
+separator " | "   // e.g. " Ctrl + n  new  |  Ctrl + w  close "
+separator " · "
+```
+
+### `max_keys`
+
+Limits how many alternative keybindings are shown for each action. Zellij merges
+`shared_except` blocks into every mode, so an action like "move focus" can accumulate
+8+ bound keys (`h|j|k|l|←|↓|↑|→`). Setting `max_keys` trims this to the first N entries.
+
+```kdl
+max_keys "4"   // show at most 4 alternatives per action
+```
+
+Keys are shown in the order Zellij reports them, which typically puts mode-specific
+bindings before shared ones. `0` (the default) shows all keys.
+
+### `alias_{label}` — action label aliases
+
+Rename any action label in the display. Config keys use the pattern `alias_{label}`,
+where spaces in the label are replaced with underscores. The alias affects only the
+displayed text; color lookups still use the original label name.
+
+```kdl
+alias_split_right  "S→"
+alias_split_down   "S↓"
+alias_fullscreen   "full"
+alias_rename       "ren"
+alias_half_page    "½pg"
+alias_increase     "inc"
+alias_decrease     "dec"
+alias_select       "sel"
+alias_break_pane   "break"
+```
+
+### `key_alias_{key}` — bare key display aliases
+
+Replace how a special bare key is displayed. Config keys use `key_alias_{name}`,
+where `{name}` is the lowercased default representation of the key.
+
+```kdl
+key_alias_enter  "⏎"
+key_alias_space  "␣"
+key_alias_esc    "⎋"
+key_alias_tab    "⇥"
+```
+
+### Compact config recipe
+
+Combining all options for maximum space savings:
+
+```kdl
+zjstatus-hints location="..." {
+    pipe_name "zjstatus_hints"
+    modifier_style "symbol"
+    hint_format " {key} {action} "
+    separator "·"
+
+    max_keys "2"
+
+    alias_split_right "S→"
+    alias_split_down  "S↓"
+    alias_fullscreen  "full"
+    alias_rename      "ren"
+    alias_half_page   "½pg"
+    alias_increase    "inc"
+    alias_decrease    "dec"
+    alias_select      "sel"
+    alias_break_pane  "break"
+
+    key_alias_enter "⏎"
+    key_alias_space "␣"
+}
+```
+
+This produces output similar to:
+
+```
+ n new · x close · f full · w float · e embed · r S→ · d S↓ · ←→ move · ⏎ sel
+```
+
+## Color customization
+
+zjstatus-hints supports full color customization so you can match hint colors to your zjstatus theme.
+All color values are hex strings (`"#RRGGBB"`).  If a color option is omitted the plugin falls back
+to the Zellij palette (backward-compatible default behavior).
+
+### Global color defaults
+
+Override the palette-derived colors for every hint:
+
+```kdl
+zjstatus-hints location="..." {
+    key_fg   "#ffffff"   // foreground of the key (keybinding) block
+    key_bg   "#6e5fb7"   // background of the key block
+    label_fg "#cccccc"   // foreground of the action label block
+    label_bg "#4c435c"   // background of the action label block
+}
+```
+
+### Per-label color overrides
+
+Override colors for a specific action label across all modes.  Labels with spaces use underscores
+in the config key (`split_right_key_bg` → label `"split right"`).
+
+```kdl
+zjstatus-hints location="..." {
+    quit_key_bg    "#ff0000"
+    quit_label_bg  "#cc0000"
+    select_key_bg  "#00aa00"
+    split_right_key_bg "#0066ff"
+}
+```
+
+### Mode-specific overrides
+
+Prefix the label key with `{mode}.` to target a single mode only:
+
+```kdl
+zjstatus-hints location="..." {
+    pane.new_key_bg    "#00ffcc"
+    tab.close_key_bg   "#ff6666"
+    pane.split_right_key_fg "#ffffff"
+}
+```
+
+### Lookup priority (per field, independently)
+
+For each color field (`key_fg`, `key_bg`, `label_fg`, `label_bg`) the plugin resolves the value in
+this order, stopping at the first match:
+
+1. Mode-specific label override — `pane.new_key_bg`
+2. Global label override — `new_key_bg`
+3. Global default — `key_bg`
+4. Zellij palette (built-in fallback)
+
+Fields are merged independently: a mode-specific override can set `key_bg` while a global label
+override provides `label_fg`.
+
+### Full color config example
+
+```kdl
+zjstatus-hints location="..." {
+    pipe_name "zjstatus_hints"
+
+    // Global color defaults (override palette for all hints)
+    key_fg   "#ffffff"
+    key_bg   "#6e5fb7"
+    label_fg "#cccccc"
+    label_bg "#4c435c"
+
+    // Per-label overrides (all modes)
+    quit_key_bg   "#ff0000"
+    quit_label_bg "#cc0000"
+    select_key_bg "#00aa00"
+
+    // Mode-specific overrides
+    pane.new_key_bg  "#00ffcc"
+    tab.close_key_bg "#ff6666"
+}
+```
+
+### Color configuration reference
+
+| Option pattern | Applies to | Slot |
+|---|---|---|
+| `key_fg` | all labels, all modes | key foreground |
+| `key_bg` | all labels, all modes | key background |
+| `label_fg` | all labels, all modes | action label foreground |
+| `label_bg` | all labels, all modes | action label background |
+| `{label}_key_fg` | named label, all modes | key foreground |
+| `{label}_key_bg` | named label, all modes | key background |
+| `{label}_label_fg` | named label, all modes | action label foreground |
+| `{label}_label_bg` | named label, all modes | action label background |
+| `{mode}.{label}_key_fg` | named label, named mode | key foreground |
+| `{mode}.{label}_key_bg` | named label, named mode | key background |
+| `{mode}.{label}_label_fg` | named label, named mode | action label foreground |
+| `{mode}.{label}_label_bg` | named label, named mode | action label background |
+
+Valid mode names: `normal`, `pane`, `tab`, `resize`, `move`, `scroll`, `search`, `session`.
 
 ## TODO
 
-- [ ] configurable colors/formatting
 - [ ] more advanced mode-specific configuration
 - [ ] improved handling of long outputs
 - [ ] ability to enable/disable specific hints

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ plugins {
         // Limit alternative keybindings shown per action (0 = unlimited)
         max_keys "0" // default
 
+        // Omit key/label background colors for a transparent look
+        transparent_bg false // default
+
         // Rename action labels in the display (spaces → underscores in key names)
         // alias_fullscreen "full"
         // alias_split_right "S→"
@@ -107,6 +110,7 @@ layout {
 | `hint_format` | `"{key} {action}"` | Template for each hint. Variables: `{key}`, `{action}`. |
 | `separator` | `""` | String inserted between hints. |
 | `max_keys` | `0` | Max alternative keybindings shown per action. `0` = unlimited. |
+| `transparent_bg` | `false` | Omit key/label background colors, even if configured. |
 | `alias_{label}` | _(none)_ | Rename an action label in the display. See below. |
 | `key_alias_{key}` | _(none)_ | Rename a special bare key in the display. See below. |
 | `key_fg` | _(palette)_ | Global foreground color for key blocks. |
@@ -229,7 +233,8 @@ This produces output similar to:
 
 zjstatus-hints supports full color customization so you can match hint colors to your zjstatus theme.
 All color values are hex strings (`"#RRGGBB"`).  If a color option is omitted the plugin falls back
-to the Zellij palette (backward-compatible default behavior).
+to the Zellij palette (backward-compatible default behavior). Set `transparent_bg true` to suppress
+all key/label background colors, including configured `key_bg` / `label_bg` overrides.
 
 ### Global color defaults
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.95.0"
 targets = [ "wasm32-wasip1" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,18 +375,32 @@ impl ZellijPlugin for State {
             PermissionType::MessageAndLaunchOtherPlugins,
         ]);
 
-        set_selectable(false);
-        subscribe(&[EventType::ModeUpdate]);
+        // NOTE: do NOT call set_selectable(false) here. zellij shows the
+        // permission grant dialog inside this plugin's pane; if the pane is
+        // unfocusable the user cannot interact with the dialog. Defer the
+        // call until permissions are confirmed (see `update`).
+        subscribe(&[
+            EventType::ModeUpdate,
+            EventType::PermissionRequestResult,
+        ]);
     }
 
     fn update(&mut self, event: Event) -> bool {
         let mut should_render = !self.initialized;
-        if let Event::ModeUpdate(mode_info) = event {
-            if self.mode_info != mode_info {
-                should_render = true;
+        match event {
+            Event::ModeUpdate(mode_info) => {
+                if self.mode_info != mode_info {
+                    should_render = true;
+                }
+                self.mode_info = mode_info;
+                self.base_mode_is_locked = self.mode_info.base_mode == Some(InputMode::Locked);
             }
-            self.mode_info = mode_info;
-            self.base_mode_is_locked = self.mode_info.base_mode == Some(InputMode::Locked);
+            Event::PermissionRequestResult(_result) => {
+                // Permissions resolved (granted or denied). Safe to hide the
+                // plugin pane from selection now.
+                set_selectable(false);
+            }
+            _ => {}
         };
         should_render
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,7 @@ struct State {
     /// User-defined display aliases for special bare keys.
     /// Key = lowercase key name (e.g. `"enter"`, `"space"`), value = replacement.
     key_aliases: HashMap<String, String>,
+    transparent_bg: bool,
 }
 
 register_plugin!(State);
@@ -364,6 +365,10 @@ impl ZellijPlugin for State {
                     .map(|key_raw| (key_raw.to_lowercase(), v.clone()))
             })
             .collect();
+        self.transparent_bg = configuration
+            .get("transparent_bg")
+            .map(|s| s.to_lowercase().parse::<bool>().unwrap_or(false))
+            .unwrap_or(false);
 
         request_permission(&[
             PermissionType::ReadApplicationState,
@@ -401,6 +406,7 @@ impl ZellijPlugin for State {
                 self.max_keys,
                 &self.action_aliases,
                 &self.key_aliases,
+                self.transparent_bg,
             );
 
             let ansi_strings = ANSIStrings(&parts);
@@ -677,6 +683,7 @@ fn style_key_with_modifier(
     label: &str,
     modifier_style: ModifierStyle,
     key_aliases: &HashMap<String, String>,
+    transparent_bg: bool,
 ) -> Vec<ANSIString<'static>> {
     if key_bindings.is_empty() {
         return vec![];
@@ -689,6 +696,13 @@ fn style_key_with_modifier(
     let bg = resolved
         .key_bg
         .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.background));
+    let base_style = || {
+        let mut style = Style::new().fg(fg);
+        if !transparent_bg {
+            style = style.on(bg);
+        }
+        style
+    };
 
     let mut styled_parts = vec![];
 
@@ -701,25 +715,19 @@ fn style_key_with_modifier(
 
     if !modifier_str.is_empty() {
         let sep = modifier_separator(modifier_style);
-        styled_parts.push(
-            Style::new()
-                .fg(fg)
-                .on(bg)
-                .bold()
-                .paint(format!(" {}{}", modifier_str, sep)),
-        );
+        styled_parts.push(base_style().bold().paint(format!(" {}{}", modifier_str, sep)));
     } else {
-        styled_parts.push(Style::new().fg(fg).on(bg).paint(" "));
+        styled_parts.push(base_style().paint(" "));
     }
 
     for (idx, key) in key_display.iter().enumerate() {
         if idx > 0 && !key_separator.is_empty() {
-            styled_parts.push(Style::new().fg(fg).on(bg).paint(key_separator));
+            styled_parts.push(base_style().paint(key_separator));
         }
-        styled_parts.push(Style::new().fg(fg).on(bg).bold().paint(key.clone()));
+        styled_parts.push(base_style().bold().paint(key.clone()));
     }
 
-    styled_parts.push(Style::new().fg(fg).on(bg).paint(" "));
+    styled_parts.push(base_style().paint(" "));
 
     styled_parts
 }
@@ -730,6 +738,7 @@ fn style_description(
     color_config: &ColorConfig,
     mode: Option<&str>,
     label: &str,
+    transparent_bg: bool,
 ) -> Vec<ANSIString<'static>> {
     let resolved = get_colors_for_label(color_config, mode, label);
     let fg = resolved
@@ -739,10 +748,12 @@ fn style_description(
         .label_bg
         .unwrap_or_else(|| palette_match!(palette.text_unselected.background));
 
-    vec![Style::new()
-        .fg(fg)
-        .on(bg)
-        .paint(format!(" {} ", description))]
+    let mut style = Style::new().fg(fg);
+    if !transparent_bg {
+        style = style.on(bg);
+    }
+
+    vec![style.paint(format!(" {} ", description))]
 }
 
 /// Plain-text key representation used by custom `hint_format` templates.
@@ -809,6 +820,7 @@ fn add_hint(
     max_keys: usize,
     action_aliases: &HashMap<String, String>,
     key_aliases: &HashMap<String, String>,
+    transparent_bg: bool,
 ) {
     if keys.is_empty() {
         return;
@@ -846,10 +858,17 @@ fn add_hint(
             description,
             modifier_style,
             key_aliases,
+            transparent_bg,
         );
         parts.extend(styled_keys);
-        let styled_desc =
-            style_description(display_label, palette, color_config, mode, description);
+        let styled_desc = style_description(
+            display_label,
+            palette,
+            color_config,
+            mode,
+            description,
+            transparent_bg,
+        );
         parts.extend(styled_desc);
     } else {
         // Custom template: render as a single plain-text string.
@@ -866,8 +885,12 @@ fn add_hint(
         let bg = resolved
             .key_bg
             .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.background));
+        let mut style = Style::new().fg(fg);
+        if !transparent_bg {
+            style = style.on(bg);
+        }
 
-        parts.push(Style::new().fg(fg).on(bg).paint(rendered));
+        parts.push(style.paint(rendered));
     }
 }
 
@@ -904,6 +927,7 @@ fn render_hints_for_mode(
     max_keys: usize,
     action_aliases: &HashMap<String, String>,
     key_aliases: &HashMap<String, String>,
+    transparent_bg: bool,
 ) -> Vec<ANSIString<'static>> {
     let mut parts = vec![];
     let select_keys = get_select_key(keymap);
@@ -924,6 +948,7 @@ fn render_hints_for_mode(
                 max_keys,
                 action_aliases,
                 key_aliases,
+                transparent_bg,
             )
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ struct State {
 
 register_plugin!(State);
 
-const TO_NORMAL: Action = Action::SwitchToMode(InputMode::Normal);
+const TO_NORMAL: Action = Action::SwitchToMode { input_mode: InputMode::Normal };
 
 const PLUGIN_SESSION_MANAGER: &str = "session-manager";
 const PLUGIN_CONFIGURATION: &str = "configuration";
@@ -39,32 +39,38 @@ type ActionLabel = (Action, &'static str);
 type ActionSequenceLabel = (&'static [Action], &'static str);
 
 const NORMAL_MODE_ACTIONS: &[ActionLabel] = &[
-    (Action::SwitchToMode(InputMode::Pane), "pane"),
-    (Action::SwitchToMode(InputMode::Tab), "tab"),
-    (Action::SwitchToMode(InputMode::Resize), "resize"),
-    (Action::SwitchToMode(InputMode::Move), "move"),
-    (Action::SwitchToMode(InputMode::Scroll), "scroll"),
-    (Action::SwitchToMode(InputMode::Search), "search"),
-    (Action::SwitchToMode(InputMode::Session), "session"),
+    (Action::SwitchToMode { input_mode: InputMode::Pane }, "pane"),
+    (Action::SwitchToMode { input_mode: InputMode::Tab }, "tab"),
+    (Action::SwitchToMode { input_mode: InputMode::Resize }, "resize"),
+    (Action::SwitchToMode { input_mode: InputMode::Move }, "move"),
+    (Action::SwitchToMode { input_mode: InputMode::Scroll }, "scroll"),
+    (Action::SwitchToMode { input_mode: InputMode::Search }, "search"),
+    (Action::SwitchToMode { input_mode: InputMode::Session }, "session"),
     (Action::Quit, "quit"),
 ];
 
 const PANE_MODE_ACTION_SEQUENCES: &[ActionSequenceLabel] = &[
-    (&[Action::NewPane(None, None, false), TO_NORMAL], "new"),
+    (
+        &[
+            Action::NewPane { direction: None, pane_name: None, start_suppressed: false },
+            TO_NORMAL,
+        ],
+        "new",
+    ),
     (&[Action::CloseFocus, TO_NORMAL], "close"),
     (&[Action::ToggleFocusFullscreen, TO_NORMAL], "fullscreen"),
     (&[Action::ToggleFloatingPanes, TO_NORMAL], "float"),
     (&[Action::TogglePaneEmbedOrFloating, TO_NORMAL], "embed"),
     (
         &[
-            Action::NewPane(Some(Direction::Right), None, false),
+            Action::NewPane { direction: Some(Direction::Right), pane_name: None, start_suppressed: false },
             TO_NORMAL,
         ],
         "split right",
     ),
     (
         &[
-            Action::NewPane(Some(Direction::Down), None, false),
+            Action::NewPane { direction: Some(Direction::Down), pane_name: None, start_suppressed: false },
             TO_NORMAL,
         ],
         "split down",
@@ -74,7 +80,17 @@ const PANE_MODE_ACTION_SEQUENCES: &[ActionSequenceLabel] = &[
 const TAB_MODE_ACTION_SEQUENCES: &[ActionSequenceLabel] = &[
     (
         &[
-            Action::NewTab(None, vec![], None, None, None, true),
+            Action::NewTab {
+                tiled_layout: None,
+                floating_layouts: vec![],
+                swap_tiled_layouts: None,
+                swap_floating_layouts: None,
+                tab_name: None,
+                should_change_focus_to_new_tab: true,
+                cwd: None,
+                initial_panes: None,
+                first_pane_unblock_condition: None,
+            },
             TO_NORMAL,
         ],
         "new",
@@ -474,8 +490,8 @@ fn render_hints_for_mode(
             let rename_keys = find_keys_for_actions(
                 keymap,
                 &[
-                    Action::SwitchToMode(InputMode::RenamePane),
-                    Action::PaneNameInput(vec![0]),
+                    Action::SwitchToMode { input_mode: InputMode::RenamePane },
+                    Action::PaneNameInput { input: vec![0] },
                 ],
                 false,
             );
@@ -486,10 +502,10 @@ fn render_hints_for_mode(
             let focus_keys = find_keys_for_action_groups(
                 keymap,
                 &[
-                    &[Action::MoveFocus(Direction::Left)],
-                    &[Action::MoveFocus(Direction::Down)],
-                    &[Action::MoveFocus(Direction::Up)],
-                    &[Action::MoveFocus(Direction::Right)],
+                    &[Action::MoveFocus { direction: Direction::Left }],
+                    &[Action::MoveFocus { direction: Direction::Down }],
+                    &[Action::MoveFocus { direction: Direction::Up }],
+                    &[Action::MoveFocus { direction: Direction::Right }],
                 ],
             );
             add_hint(&mut parts, &focus_keys, "move", colors);
@@ -506,8 +522,8 @@ fn render_hints_for_mode(
             let rename_keys = find_keys_for_actions(
                 keymap,
                 &[
-                    Action::SwitchToMode(InputMode::RenameTab),
-                    Action::TabNameInput(vec![0]),
+                    Action::SwitchToMode { input_mode: InputMode::RenameTab },
+                    Action::TabNameInput { input: vec![0] },
                 ],
                 false,
             );
@@ -536,8 +552,8 @@ fn render_hints_for_mode(
             let resize_keys = find_keys_for_action_groups(
                 keymap,
                 &[
-                    &[Action::Resize(Resize::Increase, None)],
-                    &[Action::Resize(Resize::Decrease, None)],
+                    &[Action::Resize { resize: Resize::Increase, direction: None }],
+                    &[Action::Resize { resize: Resize::Decrease, direction: None }],
                 ],
             );
             add_hint(&mut parts, &resize_keys, "resize", colors);
@@ -545,10 +561,10 @@ fn render_hints_for_mode(
             let increase_keys = find_keys_for_action_groups(
                 keymap,
                 &[
-                    &[Action::Resize(Resize::Increase, Some(Direction::Left))],
-                    &[Action::Resize(Resize::Increase, Some(Direction::Down))],
-                    &[Action::Resize(Resize::Increase, Some(Direction::Up))],
-                    &[Action::Resize(Resize::Increase, Some(Direction::Right))],
+                    &[Action::Resize { resize: Resize::Increase, direction: Some(Direction::Left) }],
+                    &[Action::Resize { resize: Resize::Increase, direction: Some(Direction::Down) }],
+                    &[Action::Resize { resize: Resize::Increase, direction: Some(Direction::Up) }],
+                    &[Action::Resize { resize: Resize::Increase, direction: Some(Direction::Right) }],
                 ],
             );
             add_hint(&mut parts, &increase_keys, "increase", colors);
@@ -556,10 +572,10 @@ fn render_hints_for_mode(
             let decrease_keys = find_keys_for_action_groups(
                 keymap,
                 &[
-                    &[Action::Resize(Resize::Decrease, Some(Direction::Left))],
-                    &[Action::Resize(Resize::Decrease, Some(Direction::Down))],
-                    &[Action::Resize(Resize::Decrease, Some(Direction::Up))],
-                    &[Action::Resize(Resize::Decrease, Some(Direction::Right))],
+                    &[Action::Resize { resize: Resize::Decrease, direction: Some(Direction::Left) }],
+                    &[Action::Resize { resize: Resize::Decrease, direction: Some(Direction::Down) }],
+                    &[Action::Resize { resize: Resize::Decrease, direction: Some(Direction::Up) }],
+                    &[Action::Resize { resize: Resize::Decrease, direction: Some(Direction::Right) }],
                 ],
             );
             add_hint(&mut parts, &decrease_keys, "decrease", colors);
@@ -569,10 +585,10 @@ fn render_hints_for_mode(
             let move_keys = find_keys_for_action_groups(
                 keymap,
                 &[
-                    &[Action::MovePane(Some(Direction::Left))],
-                    &[Action::MovePane(Some(Direction::Down))],
-                    &[Action::MovePane(Some(Direction::Up))],
-                    &[Action::MovePane(Some(Direction::Right))],
+                    &[Action::MovePane { direction: Some(Direction::Left) }],
+                    &[Action::MovePane { direction: Some(Direction::Down) }],
+                    &[Action::MovePane { direction: Some(Direction::Up) }],
+                    &[Action::MovePane { direction: Some(Direction::Right) }],
                 ],
             );
             add_hint(&mut parts, &move_keys, "move", colors);
@@ -582,8 +598,8 @@ fn render_hints_for_mode(
             let search_keys = find_keys_for_actions(
                 keymap,
                 &[
-                    Action::SwitchToMode(InputMode::EnterSearch),
-                    Action::SearchInput(vec![0]),
+                    Action::SwitchToMode { input_mode: InputMode::EnterSearch },
+                    Action::SearchInput { input: vec![0] },
                 ],
                 true,
             );
@@ -606,7 +622,7 @@ fn render_hints_for_mode(
             add_hint(&mut parts, &half_page_scroll_keys, "half page", colors);
 
             let edit_keys =
-                find_keys_for_actions(keymap, &[Action::EditScrollback, TO_NORMAL], false);
+                find_keys_for_actions(keymap, &[Action::EditScrollback { ansi: false }, TO_NORMAL], false);
             if !edit_keys.is_empty() {
                 add_hint(&mut parts, &edit_keys, "edit", colors);
             }
@@ -616,8 +632,8 @@ fn render_hints_for_mode(
             let search_keys = find_keys_for_actions(
                 keymap,
                 &[
-                    Action::SwitchToMode(InputMode::EnterSearch),
-                    Action::SearchInput(vec![0]),
+                    Action::SwitchToMode { input_mode: InputMode::EnterSearch },
+                    Action::SearchInput { input: vec![0] },
                 ],
                 true,
             );
@@ -640,11 +656,11 @@ fn render_hints_for_mode(
             add_hint(&mut parts, &half_page_scroll_keys, "half page", colors);
 
             let down_keys =
-                find_keys_for_actions(keymap, &[Action::Search(SearchDirection::Down)], true);
+                find_keys_for_actions(keymap, &[Action::Search { direction: SearchDirection::Down }], true);
             add_hint(&mut parts, &down_keys, "down", colors);
 
             let up_keys =
-                find_keys_for_actions(keymap, &[Action::Search(SearchDirection::Up)], true);
+                find_keys_for_actions(keymap, &[Action::Search { direction: SearchDirection::Up }], true);
             add_hint(&mut parts, &up_keys, "up", colors);
 
             add_hint(&mut parts, &select_keys, "select", colors);
@@ -673,7 +689,7 @@ fn render_hints_for_mode(
         }
         _ => {
             let keys =
-                find_keys_for_actions(keymap, &[Action::SwitchToMode(InputMode::Normal)], true);
+                find_keys_for_actions(keymap, &[Action::SwitchToMode { input_mode: InputMode::Normal }], true);
             add_hint(&mut parts, &keys, "normal", colors);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,184 @@ use ansi_term::{
     Colour::{Fixed, RGB},
     Style,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use zellij_tile::prelude::actions::Action;
 use zellij_tile::prelude::actions::SearchDirection;
 use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
+
+// ---------------------------------------------------------------------------
+// Modifier style
+// ---------------------------------------------------------------------------
+
+#[derive(Default, Clone, Copy, PartialEq)]
+enum ModifierStyle {
+    #[default]
+    Long,
+    Short,
+    Symbol,
+}
+
+impl ModifierStyle {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "short" => Self::Short,
+            "symbol" => Self::Symbol,
+            _ => Self::Long,
+        }
+    }
+}
+
+const DEFAULT_MODIFIER_STYLE: ModifierStyle = ModifierStyle::Long;
+const DEFAULT_HINT_FORMAT: &str = "{key} {action}";
+const DEFAULT_SEPARATOR: &str = "";
+
+// ---------------------------------------------------------------------------
+// Color configuration
+// ---------------------------------------------------------------------------
+
+/// Per-label color slots.  Each field is `None` when not configured, which
+/// causes the caller to fall back to the Zellij palette.
+#[derive(Default, Clone, Copy)]
+struct LabelColors {
+    key_fg: Option<ansi_term::Colour>,
+    key_bg: Option<ansi_term::Colour>,
+    label_fg: Option<ansi_term::Colour>,
+    label_bg: Option<ansi_term::Colour>,
+}
+
+/// Full color configuration parsed from the plugin config block.
+#[derive(Default, Clone)]
+struct ColorConfig {
+    /// Global defaults that override the palette for all labels.
+    defaults: LabelColors,
+    /// Per-label (and optionally per-mode) overrides.
+    /// Keys: `"new"`, `"pane.new"`, `"split right"`, `"pane.split right"`, …
+    overrides: HashMap<String, LabelColors>,
+}
+
+/// Parse `"#RRGGBB"` (or `"RRGGBB"`) into an `ansi_term::Colour`.
+/// Returns `None` for any other format — invalid values are silently ignored.
+fn parse_hex_color(s: &str) -> Option<ansi_term::Colour> {
+    let hex = s.trim().trim_start_matches('#');
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(RGB(r, g, b))
+}
+
+/// Scan the config map for keys matching `*_key_fg`, `*_key_bg`, `*_label_fg`,
+/// `*_label_bg` and build the per-label override table.
+///
+/// Naming convention:
+/// - `select_key_bg`          → label `"select"`, all modes
+/// - `split_right_key_bg`     → label `"split right"`, all modes
+/// - `pane.new_key_bg`        → label `"new"`, mode `"pane"` only
+/// - `pane.split_right_key_bg`→ label `"split right"`, mode `"pane"` only
+///
+/// Global defaults (`key_fg`, `key_bg`, `label_fg`, `label_bg`) are handled
+/// separately in `load()` and are NOT inserted into this map.
+fn parse_label_overrides(config: &BTreeMap<String, String>) -> HashMap<String, LabelColors> {
+    // Suffixes we recognise, ordered longest-first so `_label_fg` is checked
+    // before a hypothetical shorter suffix never conflicts.
+    const SUFFIXES: &[&str] = &["_key_fg", "_key_bg", "_label_fg", "_label_bg"];
+
+    // These bare keys are the global defaults — handled elsewhere.
+    const GLOBAL_DEFAULTS: &[&str] = &["key_fg", "key_bg", "label_fg", "label_bg"];
+
+    let mut overrides: HashMap<String, LabelColors> = HashMap::new();
+
+    'outer: for (config_key, value) in config.iter() {
+        // Skip the four global-default keys.
+        if GLOBAL_DEFAULTS.contains(&config_key.as_str()) {
+            continue;
+        }
+
+        for suffix in SUFFIXES {
+            if !config_key.ends_with(suffix) {
+                continue;
+            }
+
+            // Everything before the suffix is either `"label"` or
+            // `"mode.label"` (with underscores standing in for spaces).
+            let raw_prefix = &config_key[..config_key.len() - suffix.len()];
+            if raw_prefix.is_empty() {
+                continue 'outer;
+            }
+
+            // Build the lookup key used in `overrides`.
+            let lookup_key = if let Some(dot) = raw_prefix.find('.') {
+                let mode = &raw_prefix[..dot];
+                let label_raw = &raw_prefix[dot + 1..];
+                if mode.is_empty() || label_raw.is_empty() {
+                    continue 'outer;
+                }
+                // Labels use underscores in config but spaces internally.
+                format!("{}.{}", mode, label_raw.replace('_', " "))
+            } else {
+                // Label-only.
+                let label = raw_prefix.replace('_', " ");
+                label
+            };
+
+            // Guard against whitespace-only results.
+            if lookup_key.trim().is_empty() {
+                continue 'outer;
+            }
+
+            if let Some(color) = parse_hex_color(value) {
+                let entry = overrides.entry(lookup_key).or_default();
+                match *suffix {
+                    "_key_fg" => entry.key_fg = Some(color),
+                    "_key_bg" => entry.key_bg = Some(color),
+                    "_label_fg" => entry.label_fg = Some(color),
+                    "_label_bg" => entry.label_bg = Some(color),
+                    _ => {}
+                }
+            }
+
+            // Each config key can only match one suffix.
+            continue 'outer;
+        }
+    }
+
+    overrides
+}
+
+/// Resolve the effective colors for `label` in `mode`, applying the 4-level
+/// priority independently for each color slot:
+///
+/// 1. `"{mode}.{label}"` override  (most specific)
+/// 2. `"{label}"` override
+/// 3. Global default
+/// 4. Caller falls back to Zellij palette (when `None` is returned)
+fn get_colors_for_label(config: &ColorConfig, mode: Option<&str>, label: &str) -> LabelColors {
+    let mode_specific = mode.and_then(|m| config.overrides.get(&format!("{}.{}", m, label)));
+    let label_only = config.overrides.get(label);
+
+    // Each field resolved independently.
+    LabelColors {
+        key_fg: mode_specific.and_then(|o| o.key_fg)
+            .or_else(|| label_only.and_then(|o| o.key_fg))
+            .or(config.defaults.key_fg),
+        key_bg: mode_specific.and_then(|o| o.key_bg)
+            .or_else(|| label_only.and_then(|o| o.key_bg))
+            .or(config.defaults.key_bg),
+        label_fg: mode_specific.and_then(|o| o.label_fg)
+            .or_else(|| label_only.and_then(|o| o.label_fg))
+            .or(config.defaults.label_fg),
+        label_bg: mode_specific.and_then(|o| o.label_bg)
+            .or_else(|| label_only.and_then(|o| o.label_bg))
+            .or(config.defaults.label_bg),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin state
+// ---------------------------------------------------------------------------
 
 #[derive(Default)]
 struct State {
@@ -18,6 +191,18 @@ struct State {
     max_length: usize,
     overflow_str: String,
     hide_in_base_mode: bool,
+    modifier_style: ModifierStyle,
+    hint_format: String,
+    separator: String,
+    color_config: ColorConfig,
+    /// Maximum number of alternative keybindings shown per action (0 = unlimited).
+    max_keys: usize,
+    /// User-defined display aliases for action labels. Key = original label
+    /// (e.g. `"split right"`), value = replacement string shown in the bar.
+    action_aliases: HashMap<String, String>,
+    /// User-defined display aliases for special bare keys.
+    /// Key = lowercase key name (e.g. `"enter"`, `"space"`), value = replacement.
+    key_aliases: HashMap<String, String>,
 }
 
 register_plugin!(State);
@@ -32,6 +217,7 @@ const PLUGIN_ABOUT: &str = "zellij:about";
 const KEY_PATTERNS_NO_SEPARATOR: &[&str] = &["HJKL", "hjkl", "←↓↑→", "←→", "↓↑", "[]"];
 
 const DEFAULT_MAX_LENGTH: usize = 0;
+const DEFAULT_MAX_KEYS: usize = 0;
 const DEFAULT_OVERFLOW_STR: &str = "...";
 const DEFAULT_PIPE_NAME: &str = "zjstatus_hints";
 
@@ -100,6 +286,10 @@ const TAB_MODE_ACTION_SEQUENCES: &[ActionSequenceLabel] = &[
     (&[Action::ToggleActiveSyncTab, TO_NORMAL], "sync"),
 ];
 
+// ---------------------------------------------------------------------------
+// ZellijPlugin impl
+// ---------------------------------------------------------------------------
+
 fn get_common_modifiers(mut key_bindings: Vec<&KeyWithModifier>) -> Vec<KeyModifier> {
     if key_bindings.is_empty() {
         return vec![];
@@ -135,6 +325,45 @@ impl ZellijPlugin for State {
             .get("hide_in_base_mode")
             .map(|s| s.to_lowercase().parse::<bool>().unwrap_or(false))
             .unwrap_or(false);
+        self.modifier_style = configuration
+            .get("modifier_style")
+            .map(|s| ModifierStyle::from_str(s.as_str()))
+            .unwrap_or(DEFAULT_MODIFIER_STYLE);
+        self.hint_format = configuration
+            .get("hint_format")
+            .cloned()
+            .unwrap_or_else(|| DEFAULT_HINT_FORMAT.to_string());
+        self.separator = configuration
+            .get("separator")
+            .cloned()
+            .unwrap_or_else(|| DEFAULT_SEPARATOR.to_string());
+        self.color_config = ColorConfig {
+            defaults: LabelColors {
+                key_fg: configuration.get("key_fg").and_then(|s| parse_hex_color(s)),
+                key_bg: configuration.get("key_bg").and_then(|s| parse_hex_color(s)),
+                label_fg: configuration.get("label_fg").and_then(|s| parse_hex_color(s)),
+                label_bg: configuration.get("label_bg").and_then(|s| parse_hex_color(s)),
+            },
+            overrides: parse_label_overrides(&configuration),
+        };
+        self.max_keys = configuration
+            .get("max_keys")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_MAX_KEYS);
+        self.action_aliases = configuration
+            .iter()
+            .filter_map(|(k, v)| {
+                k.strip_prefix("alias_")
+                    .map(|label_raw| (label_raw.replace('_', " "), v.clone()))
+            })
+            .collect();
+        self.key_aliases = configuration
+            .iter()
+            .filter_map(|(k, v)| {
+                k.strip_prefix("key_alias_")
+                    .map(|key_raw| (key_raw.to_lowercase(), v.clone()))
+            })
+            .collect();
 
         request_permission(&[
             PermissionType::ReadApplicationState,
@@ -161,7 +390,18 @@ impl ZellijPlugin for State {
         let mode_info = &self.mode_info;
         let output = if !(self.hide_in_base_mode && Some(mode_info.mode) == mode_info.base_mode) {
             let keymap = get_keymap_for_mode(mode_info);
-            let parts = render_hints_for_mode(mode_info.mode, &keymap, &mode_info.style.colors);
+            let parts = render_hints_for_mode(
+                mode_info.mode,
+                &keymap,
+                &mode_info.style.colors,
+                &self.color_config,
+                self.modifier_style,
+                &self.hint_format,
+                &self.separator,
+                self.max_keys,
+                &self.action_aliases,
+                &self.key_aliases,
+            );
 
             let ansi_strings = ANSIStrings(&parts);
             let formatted = format!(" {}", ansi_strings);
@@ -187,6 +427,10 @@ impl ZellijPlugin for State {
         print!("{}", output);
     }
 }
+
+// ---------------------------------------------------------------------------
+// ANSI helpers
+// ---------------------------------------------------------------------------
 
 struct AnsiParser<'a> {
     chars: std::iter::Peekable<std::str::Chars<'a>>,
@@ -271,6 +515,10 @@ fn truncate_ansi_string(text: &str, overflow_str: &str, max_len: usize) -> Strin
     result
 }
 
+// ---------------------------------------------------------------------------
+// Key-finding helpers
+// ---------------------------------------------------------------------------
+
 fn find_keys_for_actions(
     keymap: &[(KeyWithModifier, Vec<Action>)],
     target_actions: &[Action],
@@ -309,27 +557,86 @@ fn find_keys_for_action_groups(
         .collect()
 }
 
-fn format_modifier_string(modifiers: &[KeyModifier]) -> String {
+// ---------------------------------------------------------------------------
+// Modifier rendering
+// ---------------------------------------------------------------------------
+
+fn modifier_name(modifier: &KeyModifier, style: ModifierStyle) -> String {
+    match style {
+        ModifierStyle::Long => modifier.to_string(),
+        ModifierStyle::Short => match modifier {
+            KeyModifier::Ctrl => "C".to_string(),
+            KeyModifier::Alt => "A".to_string(),
+            KeyModifier::Shift => "S".to_string(),
+            _ => modifier.to_string(),
+        },
+        ModifierStyle::Symbol => match modifier {
+            KeyModifier::Ctrl => "^".to_string(),
+            KeyModifier::Alt => "M-".to_string(),
+            KeyModifier::Shift => "S-".to_string(),
+            _ => modifier.to_string(),
+        },
+    }
+}
+
+fn format_modifier_string(modifiers: &[KeyModifier], style: ModifierStyle) -> String {
     if modifiers.is_empty() {
         String::new()
     } else {
         modifiers
             .iter()
-            .map(|m| m.to_string())
+            .map(|m| modifier_name(m, style))
             .collect::<Vec<_>>()
             .join("-")
     }
 }
 
+fn modifier_separator(style: ModifierStyle) -> &'static str {
+    match style {
+        ModifierStyle::Long => " + ",
+        ModifierStyle::Short => "-",
+        ModifierStyle::Symbol => "",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key display formatting
+// ---------------------------------------------------------------------------
+
+/// Return the display string for a bare key, applying `key_aliases` when present.
+/// The alias map uses lowercase key names as keys (e.g. `"enter"`, `"space"`).
+fn bare_key_display(bare_key: &BareKey, key_aliases: &HashMap<String, String>) -> String {
+    let default = format!("{}", bare_key);
+    // Look up by lowercased default representation.
+    key_aliases
+        .get(&default.to_lowercase())
+        .cloned()
+        .unwrap_or(default)
+}
+
 fn format_key_display(
     key_bindings: &[KeyWithModifier],
     common_modifiers: &[KeyModifier],
+    key_aliases: &HashMap<String, String>,
 ) -> Vec<String> {
     key_bindings
         .iter()
         .map(|key| {
             if common_modifiers.is_empty() {
-                format!("{}", key)
+                // Full key with modifiers already rendered by Display; we only
+                // substitute the bare-key portion so modifier prefixes are kept.
+                let bare = bare_key_display(&key.bare_key, key_aliases);
+                if key.key_modifiers.is_empty() {
+                    bare
+                } else {
+                    let mods = key
+                        .key_modifiers
+                        .iter()
+                        .map(|m| m.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!("{} {}", mods, bare)
+                }
             } else {
                 let unique_modifiers = key
                     .key_modifiers
@@ -338,10 +645,11 @@ fn format_key_display(
                     .map(|m| m.to_string())
                     .collect::<Vec<_>>()
                     .join(" ");
+                let bare = bare_key_display(&key.bare_key, key_aliases);
                 if unique_modifiers.is_empty() {
-                    format!("{}", key.bare_key)
+                    bare
                 } else {
-                    format!("{} {}", unique_modifiers, key.bare_key)
+                    format!("{} {}", unique_modifiers, bare)
                 }
             }
         })
@@ -357,68 +665,106 @@ fn get_key_separator(key_display: &[String]) -> &'static str {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Styled rendering
+// ---------------------------------------------------------------------------
+
 fn style_key_with_modifier(
     key_bindings: &[KeyWithModifier],
     palette: &Styling,
+    color_config: &ColorConfig,
+    mode: Option<&str>,
+    label: &str,
+    modifier_style: ModifierStyle,
+    key_aliases: &HashMap<String, String>,
 ) -> Vec<ANSIString<'static>> {
     if key_bindings.is_empty() {
         return vec![];
     }
 
-    let saturated_bg = palette_match!(palette.ribbon_unselected.background);
-    let contrasting_fg = palette_match!(palette.ribbon_unselected.base);
+    let resolved = get_colors_for_label(color_config, mode, label);
+    let fg = resolved
+        .key_fg
+        .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.base));
+    let bg = resolved
+        .key_bg
+        .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.background));
+
     let mut styled_parts = vec![];
 
     let common_modifiers = get_common_modifiers(key_bindings.iter().collect());
-    let modifier_str = format_modifier_string(&common_modifiers);
-    let key_display = format_key_display(key_bindings, &common_modifiers);
+    let modifier_str = format_modifier_string(&common_modifiers, modifier_style);
+    let key_display = format_key_display(key_bindings, &common_modifiers, key_aliases);
     let key_separator = get_key_separator(&key_display);
 
     styled_parts.push(Style::new().paint(" "));
 
     if !modifier_str.is_empty() {
+        let sep = modifier_separator(modifier_style);
         styled_parts.push(
             Style::new()
-                .fg(contrasting_fg)
-                .on(saturated_bg)
+                .fg(fg)
+                .on(bg)
                 .bold()
-                .paint(format!(" {} + ", modifier_str)),
+                .paint(format!(" {}{}", modifier_str, sep)),
         );
     } else {
-        styled_parts.push(Style::new().fg(contrasting_fg).on(saturated_bg).paint(" "));
+        styled_parts.push(Style::new().fg(fg).on(bg).paint(" "));
     }
 
     for (idx, key) in key_display.iter().enumerate() {
         if idx > 0 && !key_separator.is_empty() {
-            styled_parts.push(
-                Style::new()
-                    .fg(contrasting_fg)
-                    .on(saturated_bg)
-                    .paint(key_separator),
-            );
+            styled_parts.push(Style::new().fg(fg).on(bg).paint(key_separator));
         }
-        styled_parts.push(
-            Style::new()
-                .fg(contrasting_fg)
-                .on(saturated_bg)
-                .bold()
-                .paint(key.clone()),
-        );
+        styled_parts.push(Style::new().fg(fg).on(bg).bold().paint(key.clone()));
     }
 
-    styled_parts.push(Style::new().fg(contrasting_fg).on(saturated_bg).paint(" "));
+    styled_parts.push(Style::new().fg(fg).on(bg).paint(" "));
 
     styled_parts
 }
 
-fn style_description(description: &str, palette: &Styling) -> Vec<ANSIString<'static>> {
-    let less_saturated_bg = palette_match!(palette.text_unselected.background);
-    let contrasting_fg = palette_match!(palette.text_unselected.base);
+fn style_description(
+    description: &str,
+    palette: &Styling,
+    color_config: &ColorConfig,
+    mode: Option<&str>,
+    label: &str,
+) -> Vec<ANSIString<'static>> {
+    let resolved = get_colors_for_label(color_config, mode, label);
+    let fg = resolved
+        .label_fg
+        .unwrap_or_else(|| palette_match!(palette.text_unselected.base));
+    let bg = resolved
+        .label_bg
+        .unwrap_or_else(|| palette_match!(palette.text_unselected.background));
 
     vec![Style::new()
-        .fg(contrasting_fg)
-        .on(less_saturated_bg)
+        .fg(fg)
+        .on(bg)
         .paint(format!(" {} ", description))]
+}
+
+/// Plain-text key representation used by custom `hint_format` templates.
+fn format_key_plain(
+    key_bindings: &[KeyWithModifier],
+    modifier_style: ModifierStyle,
+    key_aliases: &HashMap<String, String>,
+) -> String {
+    if key_bindings.is_empty() {
+        return String::new();
+    }
+    let common_modifiers = get_common_modifiers(key_bindings.iter().collect());
+    let modifier_str = format_modifier_string(&common_modifiers, modifier_style);
+    let key_display = format_key_display(key_bindings, &common_modifiers, key_aliases);
+    let key_separator = get_key_separator(&key_display);
+    let keys_str = key_display.join(key_separator);
+    if modifier_str.is_empty() {
+        keys_str
+    } else {
+        let sep = modifier_separator(modifier_style);
+        format!("{}{}{}", modifier_str, sep, keys_str)
+    }
 }
 
 fn plugin_key(
@@ -446,43 +792,177 @@ fn get_select_key(keymap: &[(KeyWithModifier, Vec<Action>)]) -> Vec<KeyWithModif
     }
 }
 
+// ---------------------------------------------------------------------------
+// Hint assembly
+// ---------------------------------------------------------------------------
+
 fn add_hint(
     parts: &mut Vec<ANSIString<'static>>,
     keys: &[KeyWithModifier],
     description: &str,
-    colors: &Styling,
+    palette: &Styling,
+    color_config: &ColorConfig,
+    mode: Option<&str>,
+    modifier_style: ModifierStyle,
+    hint_format: &str,
+    separator: &str,
+    max_keys: usize,
+    action_aliases: &HashMap<String, String>,
+    key_aliases: &HashMap<String, String>,
 ) {
-    if !keys.is_empty() {
-        let styled_keys = style_key_with_modifier(keys, colors);
+    if keys.is_empty() {
+        return;
+    }
+
+    // Apply max_keys truncation (0 = unlimited).
+    let keys = if max_keys > 0 && keys.len() > max_keys {
+        &keys[..max_keys]
+    } else {
+        keys
+    };
+
+    // Apply key_aliases to the key slice by producing rewritten keys — we do
+    // this at the display level inside format_key_plain / style_key_with_modifier
+    // by passing the alias map through.
+
+    // Displayed label: alias overrides display only; color lookups use original.
+    let display_label: &str = action_aliases
+        .get(description)
+        .map(|s| s.as_str())
+        .unwrap_or(description);
+
+    if !separator.is_empty() && !parts.is_empty() {
+        parts.push(Style::new().paint(separator.to_string()));
+    }
+
+    if hint_format == DEFAULT_HINT_FORMAT {
+        // Default layout: two distinct styled blocks (key + action).
+        // Color lookup uses original `description` label.
+        let styled_keys = style_key_with_modifier(
+            keys,
+            palette,
+            color_config,
+            mode,
+            description,
+            modifier_style,
+            key_aliases,
+        );
         parts.extend(styled_keys);
-        let styled_desc = style_description(description, colors);
+        let styled_desc =
+            style_description(display_label, palette, color_config, mode, description);
         parts.extend(styled_desc);
+    } else {
+        // Custom template: render as a single plain-text string.
+        let key_plain = format_key_plain(keys, modifier_style, key_aliases);
+        let rendered = hint_format
+            .replace("{key}", &key_plain)
+            .replace("{action}", display_label);
+
+        // Color lookup uses original `description` label.
+        let resolved = get_colors_for_label(color_config, mode, description);
+        let fg = resolved
+            .key_fg
+            .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.base));
+        let bg = resolved
+            .key_bg
+            .unwrap_or_else(|| palette_match!(palette.ribbon_unselected.background));
+
+        parts.push(Style::new().fg(fg).on(bg).paint(rendered));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Mode → string
+// ---------------------------------------------------------------------------
+
+fn mode_to_str(mode: InputMode) -> Option<&'static str> {
+    match mode {
+        InputMode::Normal => Some("normal"),
+        InputMode::Pane => Some("pane"),
+        InputMode::Tab => Some("tab"),
+        InputMode::Resize => Some("resize"),
+        InputMode::Move => Some("move"),
+        InputMode::Scroll => Some("scroll"),
+        InputMode::Search => Some("search"),
+        InputMode::Session => Some("session"),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-mode hint rendering
+// ---------------------------------------------------------------------------
 
 fn render_hints_for_mode(
     mode: InputMode,
     keymap: &[(KeyWithModifier, Vec<Action>)],
-    colors: &Styling,
+    palette: &Styling,
+    color_config: &ColorConfig,
+    modifier_style: ModifierStyle,
+    hint_format: &str,
+    separator: &str,
+    max_keys: usize,
+    action_aliases: &HashMap<String, String>,
+    key_aliases: &HashMap<String, String>,
 ) -> Vec<ANSIString<'static>> {
     let mut parts = vec![];
     let select_keys = get_select_key(keymap);
+    let mode_str = mode_to_str(mode);
+
+    macro_rules! hint {
+        ($keys:expr, $label:expr) => {
+            add_hint(
+                &mut parts,
+                $keys,
+                $label,
+                palette,
+                color_config,
+                mode_str,
+                modifier_style,
+                hint_format,
+                separator,
+                max_keys,
+                action_aliases,
+                key_aliases,
+            )
+        };
+    }
 
     match mode {
         InputMode::Normal => {
             for (action, label) in NORMAL_MODE_ACTIONS {
                 let keys = find_keys_for_actions(keymap, &[action.clone()], true);
-                add_hint(&mut parts, &keys, label, colors);
+                hint!(&keys, label);
             }
         }
         InputMode::Pane => {
             for (actions, label) in PANE_MODE_ACTION_SEQUENCES {
-                let keys = find_keys_for_actions(keymap, actions, false);
-                if !keys.is_empty() {
-                    add_hint(&mut parts, &keys, label, colors);
-                }
+                let keys = find_keys_for_actions(keymap, actions, true);
+                hint!(&keys, label);
             }
 
+            let focus_keys_full = find_keys_for_action_groups(
+                keymap,
+                &[
+                    &[Action::MoveFocusOrTab { direction: Direction::Left }],
+                    &[Action::MoveFocusOrTab { direction: Direction::Right }],
+                    &[Action::MoveFocus { direction: Direction::Left }],
+                    &[Action::MoveFocus { direction: Direction::Down }],
+                    &[Action::MoveFocus { direction: Direction::Up }],
+                    &[Action::MoveFocus { direction: Direction::Right }],
+                ],
+            );
+            let focus_keys = if focus_keys_full.contains(&KeyWithModifier::new(BareKey::Left))
+                && focus_keys_full.contains(&KeyWithModifier::new(BareKey::Right))
+            {
+                vec![
+                    KeyWithModifier::new(BareKey::Left),
+                    KeyWithModifier::new(BareKey::Right),
+                ]
+            } else {
+                focus_keys_full
+            };
+            hint!(&focus_keys, "move");
             let rename_keys = find_keys_for_actions(
                 keymap,
                 &[
@@ -492,39 +972,14 @@ fn render_hints_for_mode(
                 false,
             );
             if !rename_keys.is_empty() {
-                add_hint(&mut parts, &rename_keys, "rename", colors);
+                hint!(&rename_keys, "rename");
             }
-
-            let focus_keys = find_keys_for_action_groups(
-                keymap,
-                &[
-                    &[Action::MoveFocus { direction: Direction::Left }],
-                    &[Action::MoveFocus { direction: Direction::Down }],
-                    &[Action::MoveFocus { direction: Direction::Up }],
-                    &[Action::MoveFocus { direction: Direction::Right }],
-                ],
-            );
-            add_hint(&mut parts, &focus_keys, "move", colors);
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&select_keys, "select");
         }
         InputMode::Tab => {
             for (actions, label) in TAB_MODE_ACTION_SEQUENCES {
-                let keys = find_keys_for_actions(keymap, actions, false);
-                if !keys.is_empty() {
-                    add_hint(&mut parts, &keys, label, colors);
-                }
-            }
-
-            let rename_keys = find_keys_for_actions(
-                keymap,
-                &[
-                    Action::SwitchToMode { input_mode: InputMode::RenameTab },
-                    Action::TabNameInput { input: vec![0] },
-                ],
-                false,
-            );
-            if !rename_keys.is_empty() {
-                add_hint(&mut parts, &rename_keys, "rename", colors);
+                let keys = find_keys_for_actions(keymap, actions, true);
+                hint!(&keys, label);
             }
 
             let focus_keys_full = find_keys_for_action_groups(
@@ -541,8 +996,19 @@ fn render_hints_for_mode(
             } else {
                 focus_keys_full
             };
-            add_hint(&mut parts, &focus_keys, "move", colors);
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&focus_keys, "move");
+            let rename_keys = find_keys_for_actions(
+                keymap,
+                &[
+                    Action::SwitchToMode { input_mode: InputMode::RenameTab },
+                    Action::TabNameInput { input: vec![0] },
+                ],
+                false,
+            );
+            if !rename_keys.is_empty() {
+                hint!(&rename_keys, "rename");
+            }
+            hint!(&select_keys, "select");
         }
         InputMode::Resize => {
             let resize_keys = find_keys_for_action_groups(
@@ -552,7 +1018,7 @@ fn render_hints_for_mode(
                     &[Action::Resize { resize: Resize::Decrease, direction: None }],
                 ],
             );
-            add_hint(&mut parts, &resize_keys, "resize", colors);
+            hint!(&resize_keys, "resize");
 
             let increase_keys = find_keys_for_action_groups(
                 keymap,
@@ -563,7 +1029,7 @@ fn render_hints_for_mode(
                     &[Action::Resize { resize: Resize::Increase, direction: Some(Direction::Right) }],
                 ],
             );
-            add_hint(&mut parts, &increase_keys, "increase", colors);
+            hint!(&increase_keys, "increase");
 
             let decrease_keys = find_keys_for_action_groups(
                 keymap,
@@ -574,8 +1040,8 @@ fn render_hints_for_mode(
                     &[Action::Resize { resize: Resize::Decrease, direction: Some(Direction::Right) }],
                 ],
             );
-            add_hint(&mut parts, &decrease_keys, "decrease", colors);
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&decrease_keys, "decrease");
+            hint!(&select_keys, "select");
         }
         InputMode::Move => {
             let move_keys = find_keys_for_action_groups(
@@ -587,8 +1053,8 @@ fn render_hints_for_mode(
                     &[Action::MovePane { direction: Some(Direction::Right) }],
                 ],
             );
-            add_hint(&mut parts, &move_keys, "move", colors);
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&move_keys, "move");
+            hint!(&select_keys, "select");
         }
         InputMode::Scroll => {
             let search_keys = find_keys_for_actions(
@@ -599,30 +1065,30 @@ fn render_hints_for_mode(
                 ],
                 true,
             );
-            add_hint(&mut parts, &search_keys, "search", colors);
+            hint!(&search_keys, "search");
 
             let scroll_keys =
                 find_keys_for_action_groups(keymap, &[&[Action::ScrollDown], &[Action::ScrollUp]]);
-            add_hint(&mut parts, &scroll_keys, "scroll", colors);
+            hint!(&scroll_keys, "scroll");
 
             let page_scroll_keys = find_keys_for_action_groups(
                 keymap,
                 &[&[Action::PageScrollDown], &[Action::PageScrollUp]],
             );
-            add_hint(&mut parts, &page_scroll_keys, "page", colors);
+            hint!(&page_scroll_keys, "page");
 
             let half_page_scroll_keys = find_keys_for_action_groups(
                 keymap,
                 &[&[Action::HalfPageScrollDown], &[Action::HalfPageScrollUp]],
             );
-            add_hint(&mut parts, &half_page_scroll_keys, "half page", colors);
+            hint!(&half_page_scroll_keys, "half page");
 
             let edit_keys =
                 find_keys_for_actions(keymap, &[Action::EditScrollback { ansi: false }, TO_NORMAL], false);
             if !edit_keys.is_empty() {
-                add_hint(&mut parts, &edit_keys, "edit", colors);
+                hint!(&edit_keys, "edit");
             }
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&select_keys, "select");
         }
         InputMode::Search => {
             let search_keys = find_keys_for_actions(
@@ -633,60 +1099,60 @@ fn render_hints_for_mode(
                 ],
                 true,
             );
-            add_hint(&mut parts, &search_keys, "search", colors);
+            hint!(&search_keys, "search");
 
             let scroll_keys =
                 find_keys_for_action_groups(keymap, &[&[Action::ScrollDown], &[Action::ScrollUp]]);
-            add_hint(&mut parts, &scroll_keys, "scroll", colors);
+            hint!(&scroll_keys, "scroll");
 
             let page_scroll_keys = find_keys_for_action_groups(
                 keymap,
                 &[&[Action::PageScrollDown], &[Action::PageScrollUp]],
             );
-            add_hint(&mut parts, &page_scroll_keys, "page", colors);
+            hint!(&page_scroll_keys, "page");
 
             let half_page_scroll_keys = find_keys_for_action_groups(
                 keymap,
                 &[&[Action::HalfPageScrollDown], &[Action::HalfPageScrollUp]],
             );
-            add_hint(&mut parts, &half_page_scroll_keys, "half page", colors);
+            hint!(&half_page_scroll_keys, "half page");
 
             let down_keys =
                 find_keys_for_actions(keymap, &[Action::Search { direction: SearchDirection::Down }], true);
-            add_hint(&mut parts, &down_keys, "down", colors);
+            hint!(&down_keys, "down");
 
             let up_keys =
                 find_keys_for_actions(keymap, &[Action::Search { direction: SearchDirection::Up }], true);
-            add_hint(&mut parts, &up_keys, "up", colors);
+            hint!(&up_keys, "up");
 
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&select_keys, "select");
         }
         InputMode::Session => {
             let detach_keys = find_keys_for_actions(keymap, &[Action::Detach], true);
-            add_hint(&mut parts, &detach_keys, "detach", colors);
+            hint!(&detach_keys, "detach");
 
             if let Some(manager_key) = plugin_key(keymap, PLUGIN_SESSION_MANAGER) {
-                add_hint(&mut parts, &[manager_key], "manager", colors);
+                hint!(&[manager_key], "manager");
             }
 
             if let Some(config_key) = plugin_key(keymap, PLUGIN_CONFIGURATION) {
-                add_hint(&mut parts, &[config_key], "config", colors);
+                hint!(&[config_key], "config");
             }
 
             if let Some(plugin_key_val) = plugin_key(keymap, PLUGIN_MANAGER) {
-                add_hint(&mut parts, &[plugin_key_val], "plugins", colors);
+                hint!(&[plugin_key_val], "plugins");
             }
 
             if let Some(about_key) = plugin_key(keymap, PLUGIN_ABOUT) {
-                add_hint(&mut parts, &[about_key], "about", colors);
+                hint!(&[about_key], "about");
             }
 
-            add_hint(&mut parts, &select_keys, "select", colors);
+            hint!(&select_keys, "select");
         }
         _ => {
             let keys =
                 find_keys_for_actions(keymap, &[Action::SwitchToMode { input_mode: InputMode::Normal }], true);
-            add_hint(&mut parts, &keys, "normal", colors);
+            hint!(&keys, "normal");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ impl ZellijPlugin for State {
         ]);
 
         set_selectable(false);
-        subscribe(&[EventType::ModeUpdate, EventType::SessionUpdate]);
+        subscribe(&[EventType::ModeUpdate]);
     }
 
     fn update(&mut self, event: Event) -> bool {
@@ -176,11 +176,7 @@ impl ZellijPlugin for State {
             String::new()
         };
 
-        // HACK: Because we're not sure when zjstatus will be ready to receive messages,
-        // we'll repeatedly send messages until the user has switched to a different mode,
-        // at which point we'll assume that zjstatus has been initialized. The render function
-        // does not seem to be called too frequently, so this should be fine.
-        if !output.is_empty() && Some(mode_info.mode) != mode_info.base_mode {
+        if !output.is_empty() {
             self.initialized = true;
         }
 


### PR DESCRIPTION
## Summary

Combines two open PRs that don't apply cleanly on top of each other, plus bumps `zellij-tile{,-utils}` from 0.44.1 → 0.44.2 to match the latest released zellij.

- **#32** (eduardoleal/zellij-tile-0.44): updates `Action::*` enum variants from tuple → named-struct form to fix ABI compatibility with zellij ≥ 0.43. Without this change, the released `zjstatus-hints.wasm` simply does not load in zellij 0.44.x.
- **#30** (AdamsGH/customizable-hints): adds configurable hint formatting (`modifier_style`, `hint_format`, `separator`, `max_keys`, action/key aliases, color overrides). Resolves #5 and #12.

The two PRs both heavily rewrite `src/main.rs` and conflict on every `Action::*` match arm. This branch:

1. Starts from the PR #32 base
2. Cherry-picks PR #30's two feat commits
3. Manually resolves the conflicts in `src/main.rs` so PR #30's new config / formatting code uses the new struct-variant `Action::*` API from PR #32
4. Bumps `zellij-tile = "0.44.2"` and `zellij-tile-utils = "0.44.2"` (latest at time of writing)

## Verified

- \`cargo build --release --target wasm32-wasip1\` — clean build, produces 1.8 MB wasm
- Loaded in zellij 0.44.2 on macOS, hints render in PANE / TAB / RESIZE / etc. modes
- All PR #30 config keys still parse (manual smoke test of `modifier_style`, `separator`, `alias_*`)

## Why not separate PRs

Because of the conflict, merging them in either order requires the same manual resolution effort. Filing them separately means whoever merges second will hit the same conflicts. A combined PR documents the resolution once.

If you'd prefer the changes split (e.g. accept #32 first, then a separate "rebased on top of #32" version of #30), I can break this branch in two — let me know.

## Credits

- @eduardoleal for #32 (zellij 0.43/0.44 compat)
- @AdamsGH for #30 (customizable hints)
- This combined branch lives at https://github.com/ultranity/zjstatus-hints/tree/feat/zellij-0.44.2-and-customizable-hints

Closes #5, closes #12, supersedes #30, supersedes #32.