### PR TITLE
fix: defer set_selectable and gate pipe emission on permission grant (#31)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ struct State {
     max_length: usize,
     overflow_str: String,
     hide_in_base_mode: bool,
+    /// True once the host has resolved request_permission(). Until then,
+    /// pipe_message_to_plugin() is denied and set_selectable() races with the
+    /// in-pane permission dialog, so we defer both until this flips.
+    permissions_granted: bool,
 }
 
 register_plugin!(State);
@@ -125,23 +129,45 @@ impl ZellijPlugin for State {
             PermissionType::MessageAndLaunchOtherPlugins,
         ]);
 
-        set_selectable(false);
-        subscribe(&[EventType::ModeUpdate, EventType::SessionUpdate]);
+        subscribe(&[
+            EventType::ModeUpdate,
+            EventType::SessionUpdate,
+            EventType::PermissionRequestResult,
+        ]);
     }
 
     fn update(&mut self, event: Event) -> bool {
         let mut should_render = !self.initialized;
-        if let Event::ModeUpdate(mode_info) = event {
-            if self.mode_info != mode_info {
+        match event {
+            Event::ModeUpdate(mode_info) => {
+                if self.mode_info != mode_info {
+                    should_render = true;
+                }
+                self.mode_info = mode_info;
+                self.base_mode_is_locked = self.mode_info.base_mode == Some(InputMode::Locked);
+            }
+            Event::PermissionRequestResult(result) => {
+                // Permissions resolved (granted or denied). Only now is it safe
+                // to hide the pane from selection -- doing so in load() blocks
+                // the permission dialog that zellij renders inside this pane --
+                // and to start emitting pipe messages.
+                self.permissions_granted = matches!(result, PermissionStatus::Granted);
+                set_selectable(false);
                 should_render = true;
             }
-            self.mode_info = mode_info;
-            self.base_mode_is_locked = self.mode_info.base_mode == Some(InputMode::Locked);
+            _ => {}
         };
         should_render
     }
 
     fn render(&mut self, _rows: usize, _cols: usize) {
+        // Before permissions are granted, pipe_message_to_plugin() is denied
+        // (the message is dropped, with no retry) and application state cannot
+        // be read, so there is nothing useful to emit yet.
+        if !self.permissions_granted {
+            return;
+        }
+
         let mode_info = &self.mode_info;
         let output = if !(self.hide_in_base_mode && Some(mode_info.mode) == mode_info.base_mode) {
             let keymap = get_keymap_for_mode(mode_info);


### PR DESCRIPTION
## Fixes #31

Two permission-timing bugs make the plugin appear broken on first launch:

1. **`set_selectable(false)` is called in `load()`**, immediately after
   `request_permission()`. zellij renders the permission-grant dialog *inside
   the plugin's own pane*, so making that pane unfocusable in the same call
   leaves the user unable to interact with the dialog — the plugin looks stuck
   with no obvious way to grant permission (#31).

2. **`render()` emits the `MessageToPlugin` pipe unconditionally.** Before
   permissions resolve, `MessageAndLaunchOtherPlugins` is denied and the
   message is dropped (no retry), so hints never reach zjstatus until some
   later event happens to re-trigger a render.

## Fix

Track a `permissions_granted` flag, set from `Event::PermissionRequestResult`:

- Subscribe to `EventType::PermissionRequestResult`.
- Defer `set_selectable(false)` to that handler (it fires whether permission is
  granted *or* denied, so the pane is still hidden either way).
- Skip `render()` / pipe emission until permissions are in place.

Minimal, self-contained: ~40 lines in `src/main.rs`, no dependency or API
changes. Builds against the current `zellij-tile 0.42.2`.
